### PR TITLE
Feature/update nix

### DIFF
--- a/.config/bat/config
+++ b/.config/bat/config
@@ -1,0 +1,25 @@
+# This is `bat`s configuration file. Each line either contains a comment or
+# a command-line option that you want to pass to `bat` by default. You can
+# run `bat --help` to get a list of all possible configuration options.
+
+# Specify desired highlighting theme (e.g. "TwoDark"). Run `bat --list-themes`
+# for a list of all available themes
+--theme="Solarized (light)"
+
+# Enable this to use italic text on the terminal. This is not supported on all
+# terminal emulators (like tmux, by default):
+#--italic-text=always
+
+# Uncomment the following line to disable automatic paging:
+#--paging=never
+
+# Uncomment the following line if you are using less version >= 551 and want to
+# enable mouse scrolling support in `bat` when running inside tmux. This might
+# disable text selection, unless you press shift.
+#--pager="less --RAW-CONTROL-CHARS --quit-if-one-screen --mouse"
+
+# Syntax mappings: map a certain filename pattern to a language.
+#   Example 1: use the C++ syntax for Arduino .ino files
+#   Example 2: Use ".gitignore"-style highlighting for ".ignore" files
+#--map-syntax "*.ino:C++"
+--map-syntax ".ignore:Git Ignore"

--- a/.config/direnv/direnv.toml
+++ b/.config/direnv/direnv.toml
@@ -1,0 +1,4 @@
+[global]
+disable_stdin = true
+strict_env = true
+warn_timeout = 0

--- a/.config/gh/config.yml
+++ b/.config/gh/config.yml
@@ -1,0 +1,13 @@
+# What protocol to use when performing git operations. Supported values: ssh, https
+git_protocol: ssh
+# What editor gh should run when creating issues, pull requests, etc. If blank, will refer to environment.
+editor:
+# When to interactively prompt. This is a global config that cannot be overridden by hostname. Supported values: enabled, disabled
+prompt: enabled
+# A pager program to send command output to, e.g. "less". Set the value to "cat" to disable the pager.
+pager:
+# Aliases allow you to create nicknames for gh commands
+aliases:
+  co: 'pr checkout'
+  open: 'repo view --web'
+  create-pr: 'pr create --assignee @me --fill --web'

--- a/.config/git/config
+++ b/.config/git/config
@@ -53,4 +53,4 @@
 
 ### GitHub ###
 [url "git@github.com:"]
-  pushInsteadOf = "https://github.com"
+ pushInsteadOf = "https://github.com"

--- a/.config/mise/config.toml
+++ b/.config/mise/config.toml
@@ -5,7 +5,7 @@
 [settings]
 # plugins can read the versions files used by other version managers (if enabled by the plugin)
 # for example, .nvmrc in the case of node's nvm
-legacy_version_file = true         # デフォルトで有効（asdfと異なる）
+legacy_version_file = false
 
 # configure `mise install` to always keep the downloaded archive
 always_keep_download = false        # deleted after install by default

--- a/.config/ripgrep/config
+++ b/.config/ripgrep/config
@@ -1,0 +1,4 @@
+--hidden
+--smart-case
+
+--glob=!.git/

--- a/flake.nix
+++ b/flake.nix
@@ -1,31 +1,14 @@
 {
-  description = "y0ssi10's dotfiles";
+  description = "y0ssi10's Nix configuration";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
-    git-hooks = {
-      url = "github:cachix/git-hooks.nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-compat.follows = "flake-compat";
-    };
-    flake-parts = {
-      url = "github:hercules-ci/flake-parts";
-    };
-    hercules-ci-effects = {
-      url = "github:hercules-ci/hercules-ci-effects";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-parts.follows = "flake-parts";
-    };
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixpkgs-unstable";
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     nix-darwin = {
-      url = "github:nix-darwin/nix-darwin";
+      url = "github:LnL7/nix-darwin";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };
@@ -37,95 +20,32 @@
       home-manager,
       nix-darwin,
       ...
-    }@inputs:
+    }:
     let
       system = "aarch64-darwin";
-      pkgs = import nixpkgs { inherit system; };
     in
     {
-      apps.${system} = {
-        update = {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "update-script" ''
-              set -e
+      apps = (
+        import ./nix/apps {
+          inherit nixpkgs;
+        }
+      );
 
-              echo "Updating flake..."
-              nix flake update
-              echo "Updating home-manager..."
-              nix run nixpkgs#home-manager -- switch --flake .#y0ssi10-home
-              echo "Updating nix-darwin..."
-              nix run nix-darwin -- switch --flake .#y0ssi10-darwin
-              echo "Update complete!"
-            ''
-          );
-        };
+      darwinConfigurations = (
+        import ./nix/nix-darwin {
+          inherit system nix-darwin;
+        }
+      );
 
-        update-home = {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "update-script" ''
-              set -e
-
-              echo "Updating flake..."
-              nix flake update
-              echo "Updating home-manager..."
-              nix run nixpkgs#home-manager -- switch --flake .#y0ssi10-home
-            ''
-          );
-        };
-        update-darwin = {
-          type = "app";
-          program = toString (
-            pkgs.writeShellScript "update-script" ''
-              set -e
-
-              echo "Updating flake..."
-              nix flake update
-              echo "Updating nix-darwin..."
-              nix run nix-darwin -- switch --flake .#y0ssi10-darwin
-              echo "Update complete!"
-            ''
-          );
-        };
-      };
-
-      darwinConfigurations = {
-        y0ssi10-darwin = nix-darwin.lib.darwinSystem {
-          system = system;
-          specialArgs = {
-            username = "y0ssi10";
+      homeConfigurations = (
+        import ./nix/home-manager {
+          inherit system home-manager;
+          username = "y0ssi10";
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
           };
-          modules = [ ./nix/nix-darwin/default.nix ];
-        };
-
-        runner-darwin = nix-darwin.lib.darwinSystem {
-          system = system;
-          specialArgs = {
-            username = "runner";
-          };
-          modules = [ ./nix/nix-darwin/default.nix ];
-        };
-
-      };
-
-      homeConfigurations = {
-        y0ssi10-home = home-manager.lib.homeManagerConfiguration {
-          pkgs = pkgs;
-          extraSpecialArgs = {
-            username = "y0ssi10";
-            inherit inputs;
-          };
-          modules = [ ./nix/home-manager/default.nix ];
-        };
-        runner-home = home-manager.lib.homeManagerConfiguration {
-          pkgs = pkgs;
-          extraSpecialArgs = {
-            username = "runner";
-            inherit inputs;
-          };
-          modules = [ ./nix/home-manager/default.nix ];
-        };
-      };
+        }
+      );
     };
 }

--- a/nix/apps/default.nix
+++ b/nix/apps/default.nix
@@ -1,0 +1,81 @@
+{ nixpkgs }:
+let
+  systems = [
+    "aarch64-darwin"
+  ];
+  eachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+  getExe = nixpkgs.lib.getExe;
+in
+eachSystem (
+  pkgs:
+  let
+    writeShellScript =
+      name: script:
+      toString (
+        pkgs.writeShellScript name ''
+          set -euo pipefail
+          while true; do
+            if [[ -f flake.nix ]]; then
+              break
+            fi
+            if [[ "$(pwd)" == "/" ]]; then
+              echo "flake.nix not found." >&2
+              exit 1
+            fi
+            cd ..
+          done
+          ESC=$(printf '\033')
+          message() {
+            printf "''${ESC}[32m==>''${ESC}[m ''${ESC}[1m%s''${ESC}[m\n" "$1"
+          }
+          ${script}
+        ''
+      );
+    system = pkgs.stdenv.hostPlatform.system;
+  in
+  {
+    default = {
+      type = "app";
+      program = writeShellScript "default" ''
+        choices=$(${getExe pkgs.gum} choose --no-limit \
+          --header="" \
+          --selected='*' \
+          --cursor-prefix='○ ' \
+          --selected-prefix='● ' \
+          --unselected-prefix='○ ' \
+          --cursor.foreground='75' \
+          --selected.foreground='75' \
+          'darwin-rebuild switch' 'home-manager switch' 'brew upgrade')
+        IFS=$'\n'
+        for choice in $choices; do
+          message "$choice"
+          case "$choice" in
+            'darwin-rebuild switch')
+              if [[ ! "${system}" =~ ^(aarch64|x86_64)-darwin$ ]]; then
+                echo "System is not supported: ${system}" >&2
+              else
+                if type darwin-rebuild >/dev/null; then
+                  sudo darwin-rebuild switch --flake .#default
+                else
+                  sudo nix run nix-darwin -- switch --flake .#default
+                fi
+              fi
+              ;;
+            'home-manager switch')
+              if type home-manager >/dev/null; then
+                home-manager switch --flake .#default
+              else
+                ${getExe pkgs.home-manager} switch --flake .#default
+              fi
+              ;;
+            'brew upgrade')
+              brew upgrade
+              ;;
+          esac
+        done
+        unset IFS
+        ${getExe pkgs.noti} -t 'Nix App (dotfiles)' -m 'finished'
+      '';
+    };
+  }
+)

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -1,153 +1,118 @@
 {
-  inputs,
-  lib,
-  config,
-  pkgs,
+  system,
   username,
-  ...
+  home-manager,
+  pkgs,
 }:
+let
+  homeDirectory =
+    if pkgs.stdenv.hostPlatform.isDarwin then
+      "/Users/${username}"
+    else
+      throw "Unsupported system: ${system}";
+in
 {
-  nixpkgs = {
-    config = {
-      allowUnfree = true;
-    };
-  };
-
-  home = {
-    username = username;
-    homeDirectory = "/Users/${username}";
-    stateVersion = "25.11";
-    packages = with pkgs; [
-      bash
-      # bat
-      gettext
-      coreutils
-      curl
-      diffutils
-      # direnv
-      # docker-completion
-      # docker
-      # eza
-      # fastfetch
-      fd
-      findutils
-      # fzf
-      gawk
-      # gh
-      ghq
-      # ghr
-      git
-      # git-secrets
-      gnused
-      gnupg
-      gnugrep
-      jq
-      k9s
-      kubectl
-      # keyring
-      kind
-      # lazygit
-      # mise
-      # navi
-      # neovim
-      # nkf
-      # ripgrep
-      sheldon
-      shellcheck
-      starship
-      tmux
-      # vim
-      zsh
-      yq
-      nix-zsh-completions
-      lazydocker
+  default = home-manager.lib.homeManagerConfiguration {
+    inherit pkgs;
+    modules = [
+      {
+        home = {
+          inherit username;
+          homeDirectory = homeDirectory;
+          stateVersion = "25.11";
+        };
+        programs.home-manager.enable = true;
+      }
+      {
+        home.packages = with pkgs; [
+          bash
+          bat
+          coreutils
+          curl
+          diffutils
+          direnv
+          docker
+          eza
+          fastfetch
+          fd
+          findutils
+          fzf
+          gawk
+          gettext
+          gh
+          ghq
+          git
+          gnused
+          gnupg
+          gnugrep
+          jq
+          k9s
+          kubectl
+          kind
+          lazygit
+          mise
+          navi
+          neovim
+          nkf
+          ripgrep
+          lazydocker
+          nix-zsh-completions
+          ripgrep
+          sheldon
+          shellcheck
+          starship
+          tmux
+          vim
+          yq
+        ];
+      }
+      {
+        home.file.".zshenv".text = ''
+          # Set ZDOTDIR before loading the actual .zshenv
+          export XDG_CONFIG_HOME="${homeDirectory}/.config"
+          export ZDOTDIR="$XDG_CONFIG_HOME/zsh"
+          
+          # Source the actual .zshenv from ZDOTDIR
+          if [[ -f "$ZDOTDIR/.zshenv" ]]; then
+            source "$ZDOTDIR/.zshenv"
+          fi
+        '';
+      }
+      {
+        xdg = {
+          enable = true;
+          configHome = "${homeDirectory}/.config";
+          cacheHome  = "${homeDirectory}/.cache";
+          dataHome   = "${homeDirectory}/.local/share";
+          stateHome  = "${homeDirectory}/.local/state";
+          configFile = {
+            "alacritty/alacritty.toml".source = ./../../.config/alacritty/alacritty.toml;
+            "bat/config".source = ./../../.config/bat/config;
+            "direnv/direnv.toml".source = ./../../.config/direnv/direnv.toml;
+            "gh/config.yml".source = ./../../.config/gh/config.yml;
+            "git/config".source = ./../../.config/git/config;
+            "git/ignore".source = ./../../.config/git/ignore;
+            "gnupg/gpg-agent.conf".source = ./../../.config/gnupg/gpg-agent.conf;
+            "lazygit/config.yml".source = ./../../.config/lazygit/config.yml;
+            "mise/config.toml".source = ./../../.config/mise/config.toml;
+            "navi/config.yaml".source = ./../../.config/navi/config.yaml;
+            "navi/snippets".source = ./../../.config/navi/snippets;
+            "navi/snippets".recursive = true;
+            "npm/npmrc".source = ./../../.config/npm/npmrc;
+            "python/startup.py".source = ./../../.config/python/startup.py;
+            "scripts".source = ./../../.config/scripts;
+            "scripts".recursive = true;
+            "starship.toml".source = ./../../.config/starship/starship.toml;
+            "tmux".source = ./../../.config/tmux;
+            "tmux".recursive = true;
+            "zsh/.zshrc".source = ./../../.config/zsh/.zshrc;
+            "zsh/.zshenv".source = ./../../.config/zsh/.zshenv;
+            "zsh/.zprofile".source = ./../../.config/zsh/.zprofile;
+            "zsh/lazy.zsh".source = ./../../.config/zsh/lazy.zsh;
+            "zsh/plugins.toml".source = ./../../.config/zsh/plugins.toml;
+          };
+        };
+      }
     ];
   };
-
-  xdg = {
-    enable = true;
-    configHome = "${config.home.homeDirectory}/.config";
-    cacheHome  = "${config.home.homeDirectory}/.cache";
-    dataHome   = "${config.home.homeDirectory}/.local/share";
-    stateHome  = "${config.home.homeDirectory}/.local/state";
-  };
-
-  programs.home-manager.enable = true;
-  programs.gh = {
-    enable = true;
-    settings = {
-      git_protocol = "ssh";
-      prompt = "enabled";
-      aliases = {
-        co = "pr checkout";
-        open = "repo view --web";
-        create-pr = "pr create --assignee @me --fill --web";
-      };
-    };
-    extensions = with pkgs; [
-      gh-copilot
-      gh-dash
-      gh-markdown-preview
-      gh-notify
-    ];
-  };
-
-  # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.alacritty.enable
-  # programs.alacritty.enable = true;
-  programs.bat = {
-    enable = true;
-    extraPackages = with pkgs.bat-extras; [
-      batdiff
-      batgrep
-      batman
-      batpipe
-      batwatch
-      prettybat
-    ];
-  };
-
-  # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.bat.enable
-  programs.direnv = {
-    enable = true;
-    # config = {
-    #   disable_stdin = true;
-    #   strict_env = true;
-    #   warn_timeout = 0;
-    # };
-    # nix-direnv.enable = true;
-  };
-
-  # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.eza.enable
-  programs.eza = {
-    enable = true;
-    colors = "auto";
-    git = true;
-    icons = "auto";
-    extraOptions = [
-      "--group-directories-first"
-    ];
-  };
-
-  # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.fastfetch.enable
-  programs.fastfetch.enable = true;
-  # https://nix-community.github.io/home-manager/options.xhtml#opt-programs.fd.enable
-  programs.fd.enable = true;
-  programs.fzf.enable = true;
-  # programs.ghostty.enable = true;
-  programs.lazygit.enable = true;
-  programs.mise.enable = true;
-  programs.navi.enable = true;
-  programs.neovim.enable = true;
-  programs.ripgrep = {
-    enable = true;
-    arguments = [
-      "--hidden"
-      "--smart-case"
-
-      "--glob=!.git/"
-    ];
-  };
-  # programs.tmux.enable = true;
-  programs.vim.enable = true;
-  # programs.zsh.enable = true;
 }

--- a/nix/home-manager/default.nix
+++ b/nix/home-manager/default.nix
@@ -49,13 +49,12 @@ in
           k9s
           kubectl
           kind
+          lazydocker
           lazygit
           mise
           navi
           neovim
           nkf
-          ripgrep
-          lazydocker
           nix-zsh-completions
           ripgrep
           sheldon

--- a/nix/nix-darwin/default.nix
+++ b/nix/nix-darwin/default.nix
@@ -1,123 +1,14 @@
 {
-  lib,
-  pkgs,
-  username,
-  ...
+  system,
+  nix-darwin,
 }:
 {
-  nix = {
-    optimise.automatic = true;
-    gc = {
-      automatic = true;
-      interval = {
-        Hour = 9;
-        Minute = 0;
-      };
-      options = "--delete-older-than 14d";
-    };
-    settings = {
-      experimental-features = "nix-command flakes";
-      use-xdg-base-directories = true;
-      max-jobs = 8;
-    };
-  };
-
-  fonts = {
-    packages = with pkgs; [
-      hackgen-nf-font
-      moralerspace-hwnf
-      moralerspace-nf
-      nerd-fonts.departure-mono
-      nerd-fonts.symbols-only
-      noto-fonts-color-emoji
-      scientifica
-      twitter-color-emoji
-      udev-gothic-nf
-    ];
-  };
-
-  system = {
-    stateVersion = 6;
-    primaryUser = username;
-    defaults = {
-      NSGlobalDomain = {
-        AppleShowAllExtensions = true;
-        AppleShowAllFiles = true;
-        AppleKeyboardUIMode = 3;
-        InitialKeyRepeat = 10;
-        KeyRepeat = 1;
-      };
-
-      finder = {
-        AppleShowAllFiles = true;
-        AppleShowAllExtensions = true;
-        ShowPathbar = true;
-        # Set default path for new windows.
-        # Computer     : `PfCm`
-        # Volume       : `PfVo`
-        # $HOME        : `PfHm`
-        # Desktop      : `PfDe`
-        # Documents    : `PfDo`
-        # All My Files : `PfAF`
-        # Other…       : `PfLo`
-        NewWindowTarget = "Home";
-      };
-
-      dock = {
-        orientation = "right";
-        autohide = true;
-        tilesize = 50;
-        magnification = false;
-        show-recents = false;
-        wvous-br-corner = 4;
-        mru-spaces = false;
-      };
-    };
-
-    keyboard = {
-      enableKeyMapping = true;
-    };
-  };
-
-  homebrew = {
-    enable = true;
-    onActivation = {
-      autoUpdate = true;
-    };
-
-    brews = [
-      # Pinentry for GPG on Mac
-      "pinentry-mac"
-    ];
-
-    casks = [
-      # GPU-accelerated terminal emulator
-      "alacritty"
-      # Chromium based browser
-      "arc"
-      # App for managing battery charging. (Also installs a CLI on first use.)
-      "battery"
-      # Tool to customise input devices and automate computer systems
-      "bettertouchtool"
-      # Write, edit, and chat about your code with AI
-      "cursor"
-      "font-udev-gothic-nf"
-      # Web browser
-      "google-chrome"
-      # Japanese input software
-      "google-japanese-ime"
-      # Keymap tool for Happy Hacking Keyboard Professional (Hybrid models only)
-      "hhkb"
-      # Software for Logitech devices
-      "logi-options+"
-      # Replacement for Docker Desktop
-      "orbstack"
-      # Collaboration platform for API development
-      "postman"
-      # Control your tools with a few keystrokes
-      "raycast"
-      # Open-source code editor
-      "visual-studio-code"
+  default = nix-darwin.lib.darwinSystem {
+    inherit system;
+    modules = [
+      ./modules/nix.nix
+      ./modules/system.nix
+      ./modules/homebrew.nix
     ];
   };
 }

--- a/nix/nix-darwin/modules/homebrew.nix
+++ b/nix/nix-darwin/modules/homebrew.nix
@@ -1,0 +1,43 @@
+{
+  homebrew = {
+    enable = true;
+    onActivation = {
+      autoUpdate = true;
+    };
+    brews = [
+      # Pinentry for GPG on Mac
+      "pinentry-mac"
+    ];
+    casks = [
+      # GPU-accelerated terminal emulator
+      "alacritty"
+      # Chromium based browser
+      "arc"
+      # App for managing battery charging. (Also installs a CLI on first use.)
+      "battery"
+      # Write, edit, and chat about your code with AI
+      "cursor"
+      # Dia browser
+      "thebrowsercompany-dia"
+      "font-udev-gothic-nf"
+      # Terminal emulator that uses platform-native UI and GPU acceleration
+      "ghostty"
+      # Web browser
+      "google-chrome"
+      # Japanese input software
+      "google-japanese-ime"
+      # Software for Logitech devices
+      "logi-options+"
+      # Knowledge base that works on top of a local folder of plain text Markdown files
+      "obsidian"
+      # Replacement for Docker Desktop
+      "orbstack"
+      # Collaboration platform for API development
+      "postman"
+      # Control your tools with a few keystrokes
+      "raycast"
+      # Open-source code editor
+      "visual-studio-code"
+    ];
+  };
+}

--- a/nix/nix-darwin/modules/nix.nix
+++ b/nix/nix-darwin/modules/nix.nix
@@ -1,0 +1,30 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+{
+  nix = {
+    enable = false;
+    settings = {
+      experimental-features = "nix-command flakes";
+      use-xdg-base-directories = true;
+      max-jobs = 8;
+      trusted-users = [
+        "root"
+        "@wheel"
+      ]
+      ++ lib.optional pkgs.stdenv.isDarwin "@admin";
+    };
+    optimise.automatic = false;
+    gc = {
+      automatic = false;
+      interval = {
+        Weekday = 7;
+        Hour = 12;
+        Minute = 0;
+      };
+      options = "--delete-older-than 14d";
+    };
+  };
+}

--- a/nix/nix-darwin/modules/system.nix
+++ b/nix/nix-darwin/modules/system.nix
@@ -1,0 +1,96 @@
+{
+  system = {
+    stateVersion = 6;
+    primaryUser = "y0ssi10";
+    defaults = {
+      NSGlobalDomain = {
+        "com.apple.sound.beep.feedback" = 0;
+        "com.apple.sound.beep.volume" = 0.000;
+        "com.apple.trackpad.scaling" = 3.0;
+        # Enable showing all extensions for Finder
+        AppleShowAllExtensions = true;
+        # Enable showing all files for Finder
+        AppleShowAllFiles = true;
+        # Enable showing keyboard UI mode for Finder
+        AppleKeyboardUIMode = 3;
+        # Set initial key repeat to 12
+        InitialKeyRepeat = 12;
+        # Set key repeat to 1
+        KeyRepeat = 1;
+        # Disable press and hold for all keys
+        ApplePressAndHoldEnabled = false;
+        # Enable mouse swipe navigate with scrolls
+        AppleEnableMouseSwipeNavigateWithScrolls = true;
+        AppleInterfaceStyle = "Dark";
+        NSAutomaticCapitalizationEnabled = false;
+        NSAutomaticPeriodSubstitutionEnabled = false;
+        NSAutomaticQuoteSubstitutionEnabled = false;
+      };
+      controlcenter = {
+        # Enable Bluetooth
+        Bluetooth = true;
+        # Disable AirDrop
+        AirDrop = false;
+      };
+      finder = {
+        # Enable showing all files for Finder
+        AppleShowAllFiles = true;
+        # Enable showing all extensions for Finder
+        AppleShowAllExtensions = true;
+        # Disable creating desktop for Finder
+        CreateDesktop = false;
+        # Disable warning when changing extension for Finder
+        FXEnableExtensionChangeWarning = false;
+        # Set preferred view style for Finder to Nlsv
+        FXPreferredViewStyle = "Nlsv";
+        # Enable showing path bar for Finder
+        ShowPathbar = true;
+        # Set new window target to Home for Finder
+        NewWindowTarget = "Home";
+      };
+      dock = {
+        # Set Dock orientation to right
+        orientation = "right";
+        # Enable autohide for Dock
+        autohide = true;
+        # Set Dock tile size to 50
+        tilesize = 50;
+        # Disable magnification for Dock
+        magnification = false;
+        # Disable showing recent items for Dock
+        show-recents = false;
+        # Set Dock bottom right corner to Desktop
+        wvous-br-corner = 4;
+        # Disable automatically rearranging spaces
+        mru-spaces = false;
+        # Enable static only for Dock
+        static-only = true;
+      };
+      menuExtraClock = {
+        # Enable showing 24 hour time for menubar
+        Show24Hour = true;
+        # Enable showing date in menubar
+        ShowDate = 0;
+        # Enable showing day of month for menubar
+        ShowDayOfMonth = true;
+        # Enable showing day of week for menubar
+        ShowDayOfWeek = true;
+        # Disable showing seconds for menubar
+        ShowSeconds = false;
+      };
+      screencapture = {
+        # Set target to clipboard
+        target = "clipboard";
+      };
+      spaces = {
+        # Disable spanning displays for spaces
+        spans-displays = false;
+      };
+    };
+    keyboard = {
+      enableKeyMapping = true;
+      # Map Caps Lock to Control
+      remapCapsLockToControl = true;
+    };
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Reorganizes Nix flake into modular components and adds a small CLI app to apply system/home changes.
> 
> - **Modular flake**: `flake.nix` now imports `nix/apps`, `nix/home-manager`, and `nix/nix-darwin`; updates inputs (nixpkgs ref, nix-darwin owner) and description
> - **New Nix app**: `nix/apps/default.nix` provides an interactive script (gum-based) to run `darwin-rebuild switch`, `home-manager switch`, or `brew upgrade`
> - **Home Manager**: new `nix/home-manager/default.nix` defines `default` profile, packages, `.zshenv`, and links XDG config files (alacritty, bat, direnv, gh, git, gnupg, lazygit, mise, navi, npm, python, scripts, starship, tmux, zsh)
> - **nix-darwin split**: moves settings into `nix/nix-darwin/modules/{nix.nix,system.nix,homebrew.nix}` and exposes a `default` configuration; expands macOS defaults and Homebrew casks (adds ghostty, obsidian, dia, etc.)
> - **Dotfiles**: adds configs for `bat`, `direnv`, `gh`, and `ripgrep`; tweaks `.config/git/config` spacing and sets `mise` `legacy_version_file=false`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fcfe9258b434058d2a97b6a258b71fe414251eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->